### PR TITLE
s3 custom endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/
 s3kor.linux
 s3kor.mac
+s3kor.mac.gz
 s3kor.linux.gz
 s3kor
 s3kor.windows

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ s3kor.linux.gz
 s3kor
 s3kor.windows
 s3kor.windows.gz
+s3kor.exe
+s3kor.exe.gz

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-all: linux windows
+all: linux windows mac
 
 mac:
-	env GOOS=darwin GOARCH=amd64 go build -o s3kor
+	env GOOS=darwin GOARCH=amd64 go build -o s3kor.mac
+	gzip -fk9 s3kor.mac
 
 linux:
 	env GOOS=linux GOARCH=amd64 go build -o s3kor.linux
@@ -12,7 +13,7 @@ windows:
 	gzip -fk9 s3kor.exe
 
 clean:
-	rm -f s3kor.linux s3kor.linux.gz s3kor.exe s3kor.exe.gz s3kor
+	rm -f s3kor.linux s3kor.linux.gz s3kor.exe s3kor.exe.gz s3kor.mac s3kor.mac.gz
 
 publish-test:
 	goreleaser --snapshot --rm-dist

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: linux windows
+
 mac:
 	env GOOS=darwin GOARCH=amd64 go build -o s3kor
 
@@ -6,11 +8,11 @@ linux:
 	gzip -fk9 s3kor.linux
 
 windows:
-	env GOOS=windows GOARCH=amd64 go build -o s3kor.windows
-	gzip -fk9 s3kor.windows
+	env GOOS=windows GOARCH=amd64 go build -o s3kor.exe
+	gzip -fk9 s3kor.exe
 
 clean:
-	rm s3kor.linux s3kor.linux.gz s3kor.windows s3kor.windows.gz s3kor
+	rm -f s3kor.linux s3kor.linux.gz s3kor.exe s3kor.exe.gz s3kor
 
 publish-test:
 	goreleaser --snapshot --rm-dist

--- a/copy.go
+++ b/copy.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"github.com/vbauerster/mpb/v5"
 	"github.com/vbauerster/mpb/v5/decor"
 	"net/url"

--- a/copy.go
+++ b/copy.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"github.com/vbauerster/mpb/v5"
+	"github.com/vbauerster/mpb/v5/decor"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/vbauerster/mpb/v5"
-	"github.com/vbauerster/mpb/v5/decor"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -137,10 +137,15 @@ func (cp BucketCopier) optimizeStorageClass(size int64) string {
 	return s3.StorageClassStandard
 }
 
-func (cp *BucketCopier) copyFile(file fileJob) {
+func (cp *BucketCopier) copyFile(file fileJob, singleFile bool) {
 	var logger = zap.S()
 
-	f, err := os.Open(filepath.Join(cp.source.Path, filepath.Clean(file.path)))
+	source_path := filepath.Join(cp.source.Path, filepath.Clean(file.path))
+	if singleFile {
+		source_path = cp.source.Path
+	}
+
+	f, err := os.Open(source_path)
 	if err != nil {
 		logger.Errorf("failed to open file %q, %v", file, err)
 
@@ -152,9 +157,16 @@ func (cp *BucketCopier) copyFile(file fileJob) {
 	} else {
 		// Upload the file to S3.
 		input := cp.template
-		input.Key = aws.String(cp.dest.Path + "/" + file.path)
+		if singleFile {
+			if cp.dest.Path == "" {
+				input.Key = aws.String(cp.dest.Path + "/" + file.path)
+			}
+			input.Key = aws.String(cp.dest.Path)
+		} else {
+			input.Key = aws.String(cp.dest.Path + "/" + file.path)
+		}
 		input.Body = f
-
+		// fmt.Printf("[%+v] --> [%+v]\n", source_path, *input.Key)
 		if cp.optimize != nil {
 			input.StorageClass = aws.String(cp.optimizeStorageClass(file.info.Size()))
 		}
@@ -197,7 +209,7 @@ func (cp *BucketCopier) uploadFile() func(file fileJob) {
 				}
 			}
 		} else {
-			cp.copyFile(file)
+			cp.copyFile(file, false)
 		}
 		cp.updateBars(1, file.info.Size(), time.Since(start))
 	}
@@ -520,7 +532,7 @@ func (cp *BucketCopier) copyFileToS3() {
 			cp.copyFile(fileJob{
 				path: cp.source.Path,
 				info: info,
-			})
+			}, true)
 
 			if !cp.quiet {
 				cp.bars.count.SetTotal(1, true)

--- a/s3kor.go
+++ b/s3kor.go
@@ -24,7 +24,7 @@ import (
 var (
 	app = kingpin.New("s3kor", "s3 tools using golang concurency")
 
-	pCustomEndpointUrl = app.Flag("custom-endpoint-url", "AWS S3 Custom Endpoint URL)").String()
+	pCustomEndpointUrl = app.Flag("custom-endpoint-url", "AWS S3 Custom Endpoint URL").String()
 	pProfile           = app.Flag("profile", "AWS credentials/config file profile to use").String()
 	pRegion            = app.Flag("region", "AWS region").String()
 	pDetectRegion      = app.Flag("detect-region", "Auto detect region for the buckets").Default("false").Bool()
@@ -150,6 +150,11 @@ func setUpLogger() {
 	logger.Debug("Logging enabled")
 
 }
+
+
+// cfg := aws.NewConfig().WithRegion(s3Config.S3Region).WithCredentials(creds)
+// cfg := aws.NewConfig().WithRegion(s3Config.S3Region).WithCredentials(creds).WithEndpoint(s3Config.S3Endpoint).WithHTTPClient(httpClient)
+// svc = s3.New(session.New(), cfg)
 
 func getAwsConfig() aws.Config {
 	if *pCustomEndpointUrl == "" {


### PR DESCRIPTION
closes #19 

I tested and it works both with an AWS Snowball Edge and a VPC S3 endpoint ( https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html )


This is how I use it:

s3kor  --custom-endpoint-url=http://127.0.0.1:8080 --profile=snowball ls s3://name-of-the-snowball-bucket/

I also (check on the last commit) fixed the copying of single files.

i.e. 

./s3kor cp README.md s3://my-bucket/README.md works now
