### PR TITLE
Bugfix: Fix copy file to s3 source and destination file names being incorrect

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -140,7 +140,7 @@ func (cp BucketCopier) optimizeStorageClass(size int64) string {
 func (cp *BucketCopier) copyFile(file fileJob) {
 	var logger = zap.S()
 
-	f, err := os.Open(filepath.Join(cp.source.Path, filepath.Clean(file.path)))
+	f, err := os.Open(filepath.Join(filepath.Dir(cp.source.Path), filepath.Base(file.path)))
 	if err != nil {
 		logger.Errorf("failed to open file %q, %v", file, err)
 

--- a/copy.go
+++ b/copy.go
@@ -152,7 +152,7 @@ func (cp *BucketCopier) copyFile(file fileJob) {
 	} else {
 		// Upload the file to S3.
 		input := cp.template
-		input.Key = aws.String(cp.dest.Path + "/" + file.path)
+		input.Key = aws.String(cp.dest.Path + "/" + filepath.Base(file.path))
 		input.Body = f
 
 		if cp.optimize != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/naemono/s3kor
+module github.com/sethkor/s3kor
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sethkor/s3kor
+module github.com/naemono/s3kor
 
 go 1.14
 


### PR DESCRIPTION
I think #17 may have created additional bugs.  Note I'm trying to upload a single file to s3 from my local filesystem:

```bash
$ s3kor --verbose cp --acl=public-read --region=us-east-2 /Users/naemono/git/sensu-k8s/scripts/go/cluster-dns-check/bin/cluster-dns-check s3://my-bucket/sensu/assets/
Files            1 / 1 [==============================================================================] Done!
Size 10.3 MB / 10.3 MB [==============================================================================] 100 % 8.3 GB/s Done!
open /Users/naemono/git/sensu-k8s/scripts/go/cluster-dns-check/bin/cluster-dns-check/Users/naemono/git/sensu-k8s/scripts/go/cluster-dns-check/bin/cluster-dns-check: not a directory
```

Check the path it's trying to open, which is not correct.  There also is an issue with the destination in s3, as it (for me) wrote

```
s3://my-bucket/sensu/assets/Users/naemono/git/sensu-k8s/scripts/go/cluster-dns-check/bin/cluster-dns-check 
```

Note that it's prepending my local directory to the name.

This PR fixes the issues *for me*, but I haven't tested all potential use cases.

Also, let me know if you want me to rebase those commits down to a single commit, or if you squash on merge.